### PR TITLE
Fix issues with process launch and pipe on windows

### DIFF
--- a/src/core/engine/process.hpp
+++ b/src/core/engine/process.hpp
@@ -4,6 +4,7 @@
 #include <boost/process.hpp>
 #include <functional>
 #include <string>
+#include <filesystem>
 #include "engine.hpp"
 
 class ProcessEngine : public Engine {
@@ -15,6 +16,7 @@ class ProcessEngine : public Engine {
                                 std::function<void(const std::string &msg)> recv = {})
         : Engine(send, recv),
           m_child(path + (arguments.empty() ? "" : (" " + arguments)),
+                  boost::process::start_dir(std::filesystem::path(path).parent_path().string()),
                   boost::process::std_out > m_out,
                   boost::process::std_in < m_in) {
     }

--- a/src/core/engine/process.hpp
+++ b/src/core/engine/process.hpp
@@ -37,12 +37,21 @@ class ProcessEngine : public Engine {
         if (m_send) {
             m_send(msg);
         }
-        m_in << msg << std::endl;
+        m_in << msg;
+#ifdef _WIN32
+        m_in << "\r";
+#endif
+        m_in << std::endl;
     }
 
     [[nodiscard]] auto get_output() -> std::string {
         std::string line;
         std::getline(m_out, line);
+#ifdef _WIN32
+        if (line.back() == '\r') {
+            line.pop_back();
+        }
+#endif
         if (m_recv) {
             m_recv(line);
         }


### PR DESCRIPTION
+ Set process's working directory to its executable's directory.
+ Fix CRLF line break for process pipe on windows.